### PR TITLE
Revert "Bump urllib3 from 1.25.9 to 1.26.5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ prawcore==1.3.0
 requests==2.23.0
 six==1.14.0
 update-checker==0.17
-urllib3==1.26.5
+urllib3==1.25.9
 websocket-client==0.57.0


### PR DESCRIPTION
Reverts analphagamma/GonkBot#2

       ERROR: Cannot install -r /tmp/build_d4112d0c/requirements.txt (line 6) and urllib3==1.26.5 because these package versions have conflicting dependencies.
       
       The conflict is caused by:
           The user requested urllib3==1.26.5
           requests 2.23.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1

